### PR TITLE
F/enhance postfinance moocher

### DIFF
--- a/mooch/postfinance.py
+++ b/mooch/postfinance.py
@@ -27,13 +27,19 @@ class PostFinanceMoocher(BaseMoocher):
     identifier = 'postfinance'
     title = _('Pay with PostFinance')
 
-    def __init__(self, *, pspid, live, sha1_in, sha1_out, **kwargs):
+    def __init__(self, *, pspid, live, sha1_in, sha1_out, payment_methods=None, **kwargs):
         if any(x is None for x in (pspid, live, sha1_in, sha1_out)):
             raise ImproperlyConfigured(
                 '%s: None is not allowed in (%r, %r, %r, %r)' % (
                     self.__class__.__name__, pspid, live, sha1_in, sha1_out))
 
         self.pspid = pspid
+        # Which payment options should be shown
+        # Options: PostFinance Card, PostFinance e-finance, TWINT, PAYPAL
+        self.payment_methods = [
+            'PostFinance Card',
+            'PostFinance e-finance'
+        ] if payment_methods is None else payment_methods
         self.live = live
         self.sha1_in = sha1_in
         self.sha1_out = sha1_out
@@ -75,7 +81,7 @@ class PostFinanceMoocher(BaseMoocher):
             'payment': payment,
             'postfinance': postfinance,
             'mode': 'prod' if self.live else 'test',
-
+            'payment_methods': self.payment_methods,
             'success_url': request.build_absolute_uri(reverse(
                 '%s:postfinance_success' % self.app_name)),
             'failure_url': request.build_absolute_uri(str(self.failure_url)),

--- a/mooch/templates/mooch/postfinance_payment_form.html
+++ b/mooch/templates/mooch/postfinance_payment_form.html
@@ -18,7 +18,7 @@
     <input type="hidden" name="cancelurl" value="{{ failure_url }}">
 
     <!-- Disable credit cards and stuff, we do not have an acquirer contract -->
-    <input type="hidden" name="PMLIST" value="PostFinance Card;PostFinance e-finance">
+    <input type="hidden" name="PMLIST" value="{{ payment_methods|join:';' }}">
 
     <button type="submit">{{ moocher.title }}</button>
   </form>

--- a/tests/cov.sh
+++ b/tests/cov.sh
@@ -1,4 +1,4 @@
 #!/bin/sh
-. venv/bin/activate
+#. venv/bin/activate
 coverage run --branch --include="*flock/*" --omit="*tests*,*migrations*" ./manage.py test testapp
 coverage html

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,3 +1,4 @@
 Django==1.8.2
 coverage
 requests
+flock==0.3.0

--- a/tests/testapp/models.py
+++ b/tests/testapp/models.py
@@ -1,0 +1,5 @@
+from django.db import models
+from mooch.models import Payment
+
+class PaymentReal(Payment):
+	test = models.TextField('test')

--- a/tests/testapp/settings.py
+++ b/tests/testapp/settings.py
@@ -24,6 +24,7 @@ INSTALLED_APPS = [
 MEDIA_ROOT = '/media/'
 STATIC_URL = '/static/'
 BASEDIR = os.path.dirname(__file__)
+PROJECT_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 MEDIA_ROOT = os.path.join(BASEDIR, 'media/')
 STATIC_ROOT = os.path.join(BASEDIR, 'static/')
 SECRET_KEY = 'supersikret'
@@ -31,16 +32,21 @@ LOGIN_REDIRECT_URL = '/?login=1'
 
 ROOT_URLCONF = 'testapp.urls'
 LANGUAGES = (('en', 'English'), ('de', 'German'))
-TEMPLATE_CONTEXT_PROCESSORS = (
-    'django.contrib.auth.context_processors.auth',
-    'django.core.context_processors.debug',
-    'django.core.context_processors.i18n',
-    'django.core.context_processors.media',
-    'django.core.context_processors.static',
-    'django.core.context_processors.request',
-    'django.contrib.messages.context_processors.messages',
-)
-MIDDLEWARE_CLASSES = (
+TEMPLATES = [
+    {
+        "BACKEND": "django.template.backends.django.DjangoTemplates",
+        "DIRS": [os.path.join(PROJECT_ROOT,"..", "mooch", "templates")],
+        'APP_DIRS': True,
+        "OPTIONS": {
+            "context_processors": [
+                'django.contrib.auth.context_processors.auth',
+                'django.contrib.messages.context_processors.messages',
+            ],
+        }
+    }
+]
+
+MIDDLEWARE = (
     'django.middleware.common.CommonMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',

--- a/tests/testapp/test_flock.py
+++ b/tests/testapp/test_flock.py
@@ -90,7 +90,7 @@ class FlockTest(TestCase):
         })
 
         d = Donation.objects.get()
-        url = 'http://testserver/details/%s/' % d.id.hex
+        url = '/details/%s/' % d.id.hex
 
         self.assertRedirects(
             response,
@@ -103,7 +103,7 @@ class FlockTest(TestCase):
             'remember_my_name': '',
         })
 
-        url = 'http://testserver/psp/%s/' % d.id.hex
+        url = '/psp/%s/' % d.id.hex
         self.assertRedirects(
             response,
             url,
@@ -129,16 +129,16 @@ class FlockTest(TestCase):
 
         self.assertIsNone(d.charged_at)
 
-        response = self.client.post('/banktransfer/', {
+        response = self.client.post('/banktransfer_confirm/', {
             'id': d.id.hex,
         })
-
+        
         d.refresh_from_db()
         self.assertIsNotNone(d.charged_at)
 
         self.assertRedirects(
             response,
-            'http://testserver/thanks/',
+            '/thanks/',
         )
 
         self.assertEqual(
@@ -150,7 +150,7 @@ class FlockTest(TestCase):
 
         self.assertRedirects(
             response,
-            'http://testserver/',
+            '/',
         )
 
         self.assertListEqual(
@@ -256,7 +256,7 @@ class FlockTest(TestCase):
         })
 
         d = Donation.objects.get()
-        url = 'http://testserver/details/%s/' % d.id.hex
+        url = '/details/%s/' % d.id.hex
 
         self.assertRedirects(
             response,
@@ -357,7 +357,7 @@ class FlockTest(TestCase):
         ))
 
         ipn_data['SHASIGN'] = sha1(sha1_source.encode('utf-8')).hexdigest()
-        response = self.client.post('/postfinance/', ipn_data)
+        response = self.client.post('/postfinance_postsale/', ipn_data)
 
         self.assertEqual(
             response.status_code,

--- a/tests/testapp/test_mooch.py
+++ b/tests/testapp/test_mooch.py
@@ -1,0 +1,49 @@
+from decimal import Decimal
+from hashlib import sha1
+
+from django.core import mail
+from django.test import TestCase
+from django.test.client import RequestFactory
+from django.utils import timezone
+from django.utils.six import assertRegex
+
+#from flock.models import Donation, Project
+from testapp.models import PaymentReal
+from mooch.postfinance import PostFinanceMoocher
+from django.db import models
+
+
+def _messages(response):
+    return [m.message for m in response.context['messages']]
+
+def fake():
+    return ""
+
+class Request():
+    def build_absolute_uri(*arg):
+        return ""
+
+class MoochTest(TestCase):
+    def test_postfinance(self):
+
+        self.assertIsNotNone(PostFinanceMoocher)
+        post_finance_moocher = PostFinanceMoocher(
+            pspid = "fake",
+            live = False,
+            sha1_in = "fake",
+            sha1_out = "fake",
+            payment_methods=None,
+        )
+
+        payment = PaymentReal.objects.create(
+            amount = 100,
+            email = "fake@fake.com",
+        )
+
+        request = Request()
+        response = post_finance_moocher.payment_form(request, payment)
+        self.assertTrue('<input type="hidden" name="PMLIST" value="PostFinance Card;PostFinance e-finance">' in response)
+
+        post_finance_moocher.payment_methods = ["PostFinance Card", "TWINT", "PAYPAL"]
+        response = post_finance_moocher.payment_form(request, payment)
+        self.assertTrue('<input type="hidden" name="PMLIST" value="PostFinance Card;TWINT;PAYPAL">' in response)

--- a/tests/testapp/urls.py
+++ b/tests/testapp/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls import include, patterns, url
+from django.conf.urls import include, url
 from django.contrib import admin
 from django.contrib.staticfiles.urls import staticfiles_urlpatterns
 
@@ -6,8 +6,9 @@ from django.contrib.staticfiles.urls import staticfiles_urlpatterns
 admin.autodiscover()
 
 
-urlpatterns = patterns(
-    '',
-    url(r'^admin/', include(admin.site.urls)),
+urlpatterns = [
+    url(r'^admin/', admin.site.urls),
     url(r'', include('flock.urls')),
-) + staticfiles_urlpatterns()
+]
+
+urlpatterns += staticfiles_urlpatterns()


### PR DESCRIPTION
I enhanced the postfinance moocher to be able to accept payment_methods. You can add TWINT or PAYPAL if those methods are activated in the postinance backend.