### PR TITLE
F/improve postfinance moocher

### DIFF
--- a/mooch/postfinance.py
+++ b/mooch/postfinance.py
@@ -25,7 +25,9 @@ class PostFinanceMoocher(BaseMoocher):
     identifier = "postfinance"
     title = _("Pay with PostFinance")
 
-    def __init__(self, *, pspid, live, sha1_in, sha1_out, **kwargs):
+    def __init__(
+        self, *, pspid, live, sha1_in, sha1_out, payment_methods=None, **kwargs
+    ):
         if any(x is None for x in (pspid, live, sha1_in, sha1_out)):
             raise ImproperlyConfigured(
                 "%s: None is not allowed in (%r, %r, %r, %r)"
@@ -33,6 +35,13 @@ class PostFinanceMoocher(BaseMoocher):
             )
 
         self.pspid = pspid
+        # Which payment options should be shown
+        # Options: PostFinance Card, PostFinance e-finance, TWINT, PAYPAL
+        self.payment_methods = (
+            ["PostFinance Card", "PostFinance e-finance"]
+            if payment_methods is None
+            else payment_methods
+        )
         self.live = live
         self.sha1_in = sha1_in
         self.sha1_out = sha1_out
@@ -83,6 +92,7 @@ class PostFinanceMoocher(BaseMoocher):
                 "payment": payment,
                 "postfinance": postfinance,
                 "mode": "prod" if self.live else "test",
+                "payment_methods": self.payment_methods,
                 "success_url": request.build_absolute_uri(
                     reverse("%s:postfinance_success" % self.app_name)
                 ),

--- a/mooch/templates/mooch/postfinance_payment_form.html
+++ b/mooch/templates/mooch/postfinance_payment_form.html
@@ -17,8 +17,7 @@
     <input type="hidden" name="exceptionurl" value="{{ failure_url }}">
     <input type="hidden" name="cancelurl" value="{{ failure_url }}">
 
-    <!-- Disable credit cards and stuff, we do not have an acquirer contract -->
-    <input type="hidden" name="PMLIST" value="PostFinance Card;PostFinance e-finance">
+    <input type="hidden" name="PMLIST" value="{{ payment_methods|join:';' }}">
 
     <button type="submit">{{ moocher.title }}</button>
   </form>

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,3 +1,9 @@
-Django==1.8.2
-coverage
-requests
+certifi==2019.6.16
+chardet==3.0.4
+coverage==4.5.4
+Django==2.2.5
+idna==2.8
+pytz==2019.2
+requests==2.22.0
+sqlparse==0.3.0
+urllib3==1.25.3

--- a/tests/testapp/test_mooch.py
+++ b/tests/testapp/test_mooch.py
@@ -70,7 +70,8 @@ class MoochTest(TestCase):
         request = Request()
         response = post_finance_moocher.payment_form(request, payment)
         self.assertTrue(
-            '<input type="hidden" name="PMLIST" value="PostFinance Card;PostFinance e-finance">'
+            '<input type="hidden" name="PMLIST" ' \
+            'value="PostFinance Card;PostFinance e-finance">'
             in response
         )
 


### PR DESCRIPTION
New PR because https://github.com/matthiask/django-mooch/pull/1 was done with an older version of master.

The init method accepts an argument `payment_methods` that allows for more payment providers like TWINT and Paypal.